### PR TITLE
Add `default` key to Schema

### DIFF
--- a/singer/schema.py
+++ b/singer/schema.py
@@ -7,6 +7,7 @@ import json
 STANDARD_KEYS = [
     'selected',
     'inclusion',
+    'default',
     'description',
     'minimum',
     'maximum',
@@ -36,7 +37,7 @@ class Schema():  # pylint: disable=too-many-instance-attributes
                  selected=None, inclusion=None, description=None, minimum=None,
                  maximum=None, exclusiveMinimum=None, exclusiveMaximum=None,
                  multipleOf=None, maxLength=None, minLength=None, additionalProperties=None,
-                 anyOf=None, patternProperties=None):
+                 anyOf=None, patternProperties=None, default=None):
 
         self.type = type
         self.properties = properties
@@ -55,6 +56,7 @@ class Schema():  # pylint: disable=too-many-instance-attributes
         self.format = format
         self.additionalProperties = additionalProperties
         self.patternProperties = patternProperties
+        self.default = default
 
     def __str__(self):
         return json.dumps(self.to_dict())


### PR DESCRIPTION
# Description of change

The default keyword is supported in JSON Schema, as described here:
https://json-schema.org/understanding-json-schema/reference/generic.html#annotations

So any data for defaults within a Catalog file should be accessible through the Schema class.


# Manual QA steps
A Catalog file which looks like this:
```json
{
  "streams": [
    {
      "stream": "cortex_distributor_writes",
      "tap_stream_id": "cortex_distributor_writes",
      "schema": {
        "properties": {
          "namespace": {
            "type": "string",
            "default": "prod"
          }
        }
      }
    }
  ]
}
```

Should allow the `default` key to be accessed through:
`singer.Catalog.load(path_to_catalog_file).streams[0].schema.to_dict()["properties"]["namespace"]["default"]`


# Risks
 unknown
 
# Rollback steps
 - revert this branch
